### PR TITLE
docs: update version number in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Save pages to the [Wayback Machine](https://web.archive.org/) as part of your CI
 
 ```yaml
 name: Save my blog
-uses: JamieMagee/wayback@v1.1.1
+uses: JamieMagee/wayback@v1.2.16
 with:
   url: jamiemagee.co.uk
 ```
@@ -22,7 +22,7 @@ with:
 
 ```yaml
 name: Save my blog
-uses: JamieMagee/wayback@v1.1.1
+uses: JamieMagee/wayback@v1.2.16
 with:
   url: jamiemagee.co.uk
   saveErrors: false


### PR DESCRIPTION
Using the examples in the readme, which use the action at version 1.1.1, the “advanced” options will not be recognized — as those were added in version 1.2. This updates the version number in the examples to the latest version, v1.2.16, so that the examples will work as expected out of the box.

I would also consider creating a “v1.2” tag, which would always point to the latest 1.2.x release (i.e., “up to next minor”). Then, the specific reference to v1.2.16 in the examples could be replaced with v1.2, so subsequent bug fixes could be made available automatically to workflows depending on this action, rather than requiring manual updates.