### PR TITLE
fix: update regex for changed Internet Archive GUID format

### DIFF
--- a/src/wayback.ts
+++ b/src/wayback.ts
@@ -8,7 +8,7 @@ import log from './utils/logger';
 export default class WayBack {
   private static readonly baseWaybackUrl = 'https://web.archive.org/save';
   private static readonly statusGuidRegex =
-    /watchJob\("(?<guid>[0-9nps]{4}-[0-9a-f]{40}-[0-9a-f]{8})/;
+    /watchJob\("(?<guid>[0-9nps]{4}-[0-9a-f]{40})/;
   private url: string;
   private saveErrors: boolean;
   private saveOutlinks: boolean;

--- a/test/__fixtures__/save.html
+++ b/test/__fixtures__/save.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <script>
-      spn.watchJob("spn2-b559c7edd3fb67374c1a25e739cdd7edd1d79949-826ebe1b", "/_static/", 2000);
+      spn.watchJob("spn2-b559c7edd3fb67374c1a25e739cdd7edd1d79949", "/_static/", 2000);
     </script>
   </body>
 </html>

--- a/test/__fixtures__/wayback.pending.json
+++ b/test/__fixtures__/wayback.pending.json
@@ -1,5 +1,5 @@
 {
-  "job_id": "spn2-b559c7edd3fb67374c1a25e739cdd7edd1d79949-826ebe1b",
+  "job_id": "spn2-b559c7edd3fb67374c1a25e739cdd7edd1d79949",
   "resources": [],
   "status": "pending"
 }

--- a/test/__fixtures__/wayback.success.json
+++ b/test/__fixtures__/wayback.success.json
@@ -1,9 +1,9 @@
 {
-  "job_id": "spn2-b559c7edd3fb67374c1a25e739cdd7edd1d79949-826ebe1b",
+  "job_id": "spn2-b559c7edd3fb67374c1a25e739cdd7edd1d79949",
   "resources": [],
   "outlinks": [],
-  "timestamp": "20210610153123",
+  "timestamp": "20220328013741",
   "original_url": "https://example.com/",
   "status": "success",
-  "duration_sec": 11.582
+  "duration_sec": 4.121
 }

--- a/test/wayback.spec.ts
+++ b/test/wayback.spec.ts
@@ -6,10 +6,10 @@ import WayBack from '../src/wayback';
 import { getName } from './utils';
 
 jest.mock('../src/input');
-const testGuid = 'spn2-b559c7edd3fb67374c1a25e739cdd7edd1d79949-826ebe1b';
+const testGuid = 'spn2-b559c7edd3fb67374c1a25e739cdd7edd1d79949';
 const testDomain = 'example.com';
 const testOutput =
-  'https://web.archive.org/web/20210610153123/https://example.com/';
+  'https://web.archive.org/web/20220328013741/https://example.com/';
 const htmlResponse = fs.readFileSync('test/__fixtures__/save.html');
 const pendingJson = fs.readFileSync('test/__fixtures__/wayback.pending.json');
 const successJson = fs.readFileSync('test/__fixtures__/wayback.success.json');


### PR DESCRIPTION
Looks like the error from #73 cropped up again due to another GUID format change. This corrects the GUID regex and updates tests accordingly. Also, verified this fix as working in one of my own repos which uses this heavily :)