### PR TITLE
add input delay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Defaults to `false`.
 
 Only capture the URL if the most recent existing capture is older than this value. Accepts SPN2 timedelta strings (e.g. `1d`, `3h 20m`) or plain seconds (e.g. `3600`). Supports a comma-separated pair (e.g. `1d,7d`) to apply a different value to outlinks.
 
+### `delayBetweenRequests`
+
+Time, in milliseconds, to wait between web requests.  Use this to work with rate-limited hosting.
+
 ## Outputs
 
 ### `wayback_url`

--- a/src/input.ts
+++ b/src/input.ts
@@ -18,12 +18,16 @@ export default class Input {
   readonly ifNotArchivedWithin = this.getInput('ifNotArchivedWithin', {
     trimWhitespace: true,
   });
+  readonly delayBetweenRequests;
 
   constructor() {
     const urls = this.getMultilineInput('url', {
       required: false,
       trimWhitespace: true,
     });
+
+    const delayInput = this.getInput('delayBetweenRequests', { trimWhitespace: true });
+    this.delayBetweenRequests = delayInput ? Number(delayInput) : null;
 
     this.url = urls.length > 0 ? urls : this.detectFromCname();
     this.validate();

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -26,6 +26,9 @@ export default async function run(): Promise<void> {
       log.error(`Archive process failed for ${url}: ${err.message}`);
       failures.push({ url, error: err });
     }
+    if (input.delayBetweenRequests) {
+      await Promise.delay(input.delayBetweenRequests);
+    }
   }
 
   writeOutputs(results);


### PR DESCRIPTION
it tries to crawl my site a bit too fast and I end up with a bunch of HTTP 429s  from cloudflare, adding something to space requests out a little bit to avoid that